### PR TITLE
Update tile_config.json to fix desert mod wielded rifle not showing up

### DIFF
--- a/TILESETS/gfx/MSX++UnDeadPeopleEdition/tile_config.json
+++ b/TILESETS/gfx/MSX++UnDeadPeopleEdition/tile_config.json
@@ -8582,6 +8582,7 @@
           "fg": 4382,
           "rotates": false
         },
+        { "id": "overlay_wielded_modular_ar15", "fg": 4383, "rotates": false },
         { "id": "overlay_wielded_ar15", "fg": 4383, "rotates": false },
         { "id": "ar_pistol", "fg": 4384, "rotates": false },
         { "id": "overlay_wielded_ar_pistol", "fg": 4385, "rotates": false },


### PR DESCRIPTION
Desert mod rifle when wielded was not showing up. This fixed it.